### PR TITLE
pkcs7: allow for null validityCheckDate for consistency with x509

### DIFF
--- a/lib/pkcs7.js
+++ b/lib/pkcs7.js
@@ -621,7 +621,7 @@ p7.createSignedData = function() {
       }
 
       var verifyOpts = {};
-      if(options.validityCheckDate) {
+      if(typeof options.validityCheckDate !== 'undefined') {
         verifyOpts.validityCheckDate = options.validityCheckDate;
       }
 
@@ -648,7 +648,7 @@ p7.createSignedData = function() {
         for(var ai in signer.authenticatedAttributes) {
           switch(signer.authenticatedAttributes[ai].type) {
             case forge.pki.oids.signingTime:
-              if(!verifyOpts.validityCheckDate) {
+              if(typeof verifyOpts.validityCheckDate === 'undefined') {
                 verifyOpts.validityCheckDate = signer.authenticatedAttributes[ai].value;
               }
               break;


### PR DESCRIPTION
`pki.verifyCertificateChain`'s options state "Pass null to not check the validity period."  This allows for passing `null` through to `verifyCertificateChain`.